### PR TITLE
Update install.sh for new vehicle config

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -43,7 +43,7 @@ mv /var/www/html/scripts/docker_launch.bash /var/www/html/scripts/launch.bash
 mv /var/www/html/scripts/docker_kill.bash /var/www/html/scripts/kill.bash
 
 # Install stub carma.config.js to be overriden by later configuration
-mkdir -p /opt/carma/vehicle
-touch /opt/carma/vehicle/carma.config.js
-ln -sf /opt/carma/vehicle/carma.config.js /var/www/html/scripts/carma.config.js
-chown www-data:www-data /opt/carma/vehicle/carma.config.js
+mkdir -p /opt/carma/vehicle/config
+touch /opt/carma/vehicle/config/carma.config.js
+ln -sf /opt/carma/vehicle/config/carma.config.js /var/www/html/scripts/carma.config.js
+chown www-data:www-data /opt/carma/vehicle/config/carma.config.js


### PR DESCRIPTION
The install.sh script was pointing to the wrong file path for the new vehicle configuration. This corrects it. 