### PR TITLE
Fix docker image name

### DIFF
--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -17,7 +17,7 @@
 USERNAME=usdotfhwastol
 
 cd "$(dirname "$0")"
-IMAGE=$(./get-package-name.sh | tr '[:upper:]' '[:lower:]')
+IMAGE=$(./get-image-name.sh)
 
 echo ""
 echo "##### $IMAGE Docker Image Build Script #####"

--- a/docker/get-package-name.sh
+++ b/docker/get-package-name.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-cd "$(dirname "$0")"
-cd ..
-echo "${PWD##*/}"
-


### PR DESCRIPTION
Fixes the docker image name which was using the old get-package-name script instead of the new get-image-name script. 