### PR TITLE
Feature/gui carma version update

### DIFF
--- a/website/scripts/carmaVersion.php
+++ b/website/scripts/carmaVersion.php
@@ -1,0 +1,6 @@
+<?php
+echo exec ("docker container inspect -f '{{ index .Config.Labels \"org.label-schema.version\"}}' carma-config");
+?>
+
+
+

--- a/website/scripts/rosbridge.js
+++ b/website/scripts/rosbridge.js
@@ -83,7 +83,6 @@ var getDriversWithCap_max_trial = 10;
 var s_get_available_routes = 'get_available_routes';
 var s_set_active_route = 'set_active_route';
 var s_start_active_route = 'start_active_route';
-var s_get_system_version = 'get_system_version';
 var s_get_registered_plugins = 'plugins/get_registered_plugins';
 var s_activate_plugins = 'plugins/activate_plugin';
 var s_set_guidance_active = 'set_guidance_active';
@@ -1546,30 +1545,6 @@ function showVehicleInfo(itemName, index) {
 }
 
 /*
-    Show the system name and version on the footer.
-*/
-function showSystemVersion() {
-
-    // Calling service
-    var serviceClient = new ROSLIB.Service({
-        ros: ros,
-        name: s_get_system_version,
-        serviceType: 'cav_srvs/GetSystemVersion'
-    });
-
-    // Then we create a Service Request.
-    var request = new ROSLIB.ServiceRequest({
-    });
-
-    // Call the service and get back the results in the callback.
-    serviceClient.callService(request, function (result) {
-
-        var elemSystemVersion = document.getElementsByClassName('systemversion');
-        elemSystemVersion[0].innerHTML = result.system_name + ' ' + result.revision;
-    });
-}
-
-/*
     Subscribe to topic and add each vehicle as a marker on the map.
     If already exist, update the marker with latest long and lat.
 */
@@ -1797,7 +1772,6 @@ function showLightBarStatus (){
 function showStatusandLogs() {
     getParams();
     getVehicleInfo();
-    showSystemVersion();
     showNavSatFix();
     showSpeedAccelInfo();
     showCANSpeeds();
@@ -1894,6 +1868,32 @@ function evaluateNextStep() {
 }//evaluateNextStep
 
 /*
+    Get the CARMA version using the PHP script calling the docker container inspect to get the carma-config image version used.
+*/
+function getCARMAVersion() 
+{
+	var request = new XMLHttpRequest();
+	var url = "scripts/carmaVersion.php";
+	request.open("POST", url, true);
+	request.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+	 
+	request.onreadystatechange = function() {
+		if(request.readyState == 4 && request.status == 200) {
+		showCARMAVersion(request.responseText);
+		}
+	}
+	request.send();
+}
+
+/*
+    Show the CARMA version under the footer tag.
+*/
+function showCARMAVersion(response) {
+	var elemSystemVersion = document.getElementsByClassName('systemversion');
+	elemSystemVersion[0].innerHTML = response;
+}
+
+/*
     Onload function that gets called when first loading the page and on page refresh.
 */
 window.onload = function () {
@@ -1911,6 +1911,9 @@ window.onload = function () {
         // Adding Copyright based on current year
         var elemCopyright = document.getElementsByClassName('copyright');
         elemCopyright[0].innerHTML = '&copy LEIDOS ' + new Date().getFullYear();
+
+        // Adding CARMA Version based on the carma-config docker container version
+        getCARMAVersion();
 
         //Refresh requires connection to ROS.
         connectToROS();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->
# PR Details
## Description

<!--- Describe your changes in detail -->
Fix Github Issue 342, link below. 
Created PHP script to get the carma-config docker container version. 
Updated the rosbridge.js to leverage the PHP script and display the version. 

## Related Issue
https://github.com/usdot-fhwa-stol/CARMAPlatform/issues/342

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix UI version on the footer. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested on the Blue Lexus. 
Manually tested on local PC docker image of the web-ui. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

