### PR TITLE
Remove underscore limitation for web ui route functions

### DIFF
--- a/website/scripts/control.js
+++ b/website/scripts/control.js
@@ -107,14 +107,11 @@ function createRadioElement(container, radioId, radioTitle, itemCount, groupName
     newInput.type = 'radio';
     newInput.name = groupName;
 
-    //TODO: Remove this when RouteID has been changed to have no spaces.
-    //Currently, RouteID and RouteName are same and have spaces, but ID should not have any spaces. For now, updating to have underscore
-    var revisedId = radioId.toString().replace(/ /g, '_');
-    newInput.id = 'rb' + revisedId;
+    newInput.id = 'rb' + radioId.toString();
     newInput.onclick = function () { setRoute(newInput.id.toString()) };
 
     var newLabel = document.createElement('label');
-    newLabel.id = 'lbl' + revisedId;
+    newLabel.id = 'lbl' + radioId.toString();
     newLabel.htmlFor = newInput.id.toString();
     newLabel.innerHTML = radioTitle;
 

--- a/website/scripts/rosbridge.js
+++ b/website/scripts/rosbridge.js
@@ -420,11 +420,9 @@ function setRoute(id) {
         serviceType: 'cav_srvs/SetActiveRoute'
     });
 
-    //TODO: Remove this when Route Manager has updated the RouteID to not have spaces. For now have to do this.
-    var selectedRouteid = id.toString().replace('rb', '').replace(/_/g, ' ');
+    var selectedRouteid = id.toString().replace('rb', '');
 
-    // Then we create a Service Request.
-    // replace rb with empty string and underscore with space to go back to original ID from topic.
+    // Create a Service Request.
     var request = new ROSLIB.ServiceRequest({
         routeID: selectedRouteid
     });


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR allows route files to be named in any fashion by removing the checks for underscores and spaces from the web ui. 

## Related Issue
usdot-fhwa-stol/CARMAPlatform#407
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Prevent a source of error for developers where they misname their route files
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this on the pacifica using carma config edit to change only the active web ui image. The rest of the build was from Urus. 

I tested it with route file containing underscores in the name. 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.